### PR TITLE
Fix AA CRYO weapon cannot apply condtion to large aircraft

### DIFF
--- a/OpenRA.Mods.CA/Warheads/SpreadDamageWithConditionWarhead.cs
+++ b/OpenRA.Mods.CA/Warheads/SpreadDamageWithConditionWarhead.cs
@@ -1,0 +1,62 @@
+#region Copyright & License Information
+/**
+ * Copyright (c) The OpenRA Combined Arms Developers (see CREDITS).
+ * This file is part of OpenRA Combined Arms, which is free software.
+ * It is made available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version. For more information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Warheads;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.CA.Warheads
+{
+	[Desc("Apply Damage/Condition in a specified range related with hitshape. Condition is applied before Damage.")]
+	public class SpreadDamageWithConditionWarhead : SpreadDamageWarhead
+	{
+		[FieldLoader.Require]
+		[Desc("The condition to apply. Must be included in the target actor's ExternalConditions list.")]
+		public readonly string Condition = null;
+
+		[Desc("Duration of the condition (in ticks).")]
+		public readonly int ConditionDuration = 0;
+
+		[Desc("Condition duration percentage versus each armor type. 100% by default")]
+		public readonly Dictionary<string, int> ConditionVersus = new();
+
+		protected override void InflictDamage(Actor victim, Actor firedBy, HitShape shape, WarheadArgs args)
+		{
+			// Apply the condition first
+			var duration = Util.ApplyPercentageModifiers(ConditionDuration, new int[] { ConditionDurationVersus(victim, shape) });
+			if (duration > 0)
+				victim.TraitsImplementing<ExternalCondition>()
+					.FirstOrDefault(t => t.Info.Condition == Condition && t.CanGrantCondition(firedBy))
+					?.GrantCondition(victim, firedBy, duration);
+
+			// Then deals damage
+			var damage = Util.ApplyPercentageModifiers(Damage, args.DamageModifiers.Append(DamageVersus(victim, shape, args)));
+			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
+		}
+
+		int ConditionDurationVersus(Actor victim, HitShape shape)
+		{
+			// If no DurationVersus values are defined, DamageVersus would return 100 anyway, so we might as well do that early.
+			if (ConditionVersus.Count == 0)
+				return 100;
+
+			var armor = victim.TraitsImplementing<Armor>()
+				.Where(a => !a.IsTraitDisabled && a.Info.Type != null && ConditionVersus.ContainsKey(a.Info.Type) &&
+					(shape.Info.ArmorTypes.IsEmpty || shape.Info.ArmorTypes.Contains(a.Info.Type)))
+				.Select(a => ConditionVersus[a.Info.Type]);
+
+			return Util.ApplyPercentageModifiers(100, armor);
+		}
+	}
+}

--- a/mods/ca/weapons/missiles.yaml
+++ b/mods/ca/weapons/missiles.yaml
@@ -260,10 +260,11 @@ Dragon.CRYO:
 		Explosions: cryohit
 		ExplosionPalette: ra2effect-ignore-lighting-alpha75
 		ImpactSounds: cryohit.aud
-	Warhead@chill: GrantExternalCondition
+	Warhead@chill: SpreadDamageWithCondition
+		Spread: 0c341
+		Falloff: 100, 100
 		Condition: chilled
-		Duration: 60
-		Range: 0c341
+		ConditionDuration: 60
 		ValidRelationships: Enemy, Neutral
 
 Dragon.TibCore:
@@ -646,10 +647,11 @@ RedEye.CRYO:
 		Explosions: cryohit
 		ExplosionPalette: ra2effect-ignore-lighting-alpha75
 		ImpactSounds: cryoblast.aud
-	Warhead@chill: GrantExternalCondition
+	Warhead@chill: SpreadDamageWithCondition
+		Spread: 0c341
+		Falloff: 100, 100
 		Condition: chilled
-		Duration: 60
-		Range: 0c341
+		ConditionDuration: 60
 		ValidTargets: Air, AirSmall
 		ValidRelationships: Enemy, Neutral
 
@@ -1386,10 +1388,11 @@ IFVRocketsE.CRYO:
 		Explosions: cryohit
 		ExplosionPalette: ra2effect-ignore-lighting-alpha75
 		ImpactSounds: cryohit.aud
-	Warhead@chill: GrantExternalCondition
+	Warhead@chill: SpreadDamageWithCondition
+		Spread: 0c341
+		Falloff: 100, 100
 		Condition: chilled
-		Duration: 60
-		Range: 0c341
+		ConditionDuration: 60
 		ValidRelationships: Enemy, Neutral
 
 IFVRocketsAAE:
@@ -1414,10 +1417,11 @@ IFVRocketsAAE.CRYO:
 		Explosions: cryohit
 		ExplosionPalette: ra2effect-ignore-lighting-alpha75
 		ImpactSounds: cryoblast.aud
-	Warhead@chill: GrantExternalCondition
+	Warhead@chill: SpreadDamageWithCondition
+		Spread: 0c341
+		Falloff: 100, 100
 		Condition: chilled
-		Duration: 60
-		Range: 0c341
+		ConditionDuration: 60
 		ValidTargets: Air, AirSmall
 		ValidRelationships: Enemy, Neutral
 


### PR DESCRIPTION
Before fix:
![condition-bug](https://github.com/darkademic/CAmod/assets/13763394/9f861603-4ccb-4f1a-9fe5-37e90422e6b4)
![bug2](https://github.com/darkademic/CAmod/assets/13763394/74ae1763-201c-49b9-a848-e09f7b100493)


After fix:
![improve2](https://github.com/darkademic/CAmod/assets/13763394/395954ba-9268-482e-b577-2c74952b9c70)
![improve3](https://github.com/darkademic/CAmod/assets/13763394/57791a0b-051d-48ad-a988-64903a1d3bfa)

Add `SpreadDamageWithConditionWarhead` which apply condition regarding hitshape instead of actor center.

You can also merge a `ConditionWarhead` and a `DamageWarhead` into one `SpreadDamageWithConditionWarhead`  to improve performance and simplify the code.