### PR TITLE
Fix prologue 4 briefing typo

### DIFF
--- a/mods/ca/maps/ca-prologue-04/rules.yaml
+++ b/mods/ca/maps/ca-prologue-04/rules.yaml
@@ -6,7 +6,7 @@ World:
 	LuaScript:
 		Scripts: campaign.lua, ca-prologue-04.lua
 	MissionData:
-		Briefing: Critcial components and supplies are being transported to a secret staging area. Few in the Brotherhood know the full details of this operation, but all will be revealed in time.\n\nGDI continue to threaten vital transportation routes, and you have been chosen to secure one such route in Egypt.\n\nGDI is blockading the Nile river with their fleet, and this is unacceptably delaying our progress.\n\nEstablish a foothold, then your objective is to destroy the GDI anti-aircraft systems that line the river bank. Once those are out of the way, Kane has a surprise in store for GDI's navy.
+		Briefing: Critical components and supplies are being transported to a secret staging area. Few in the Brotherhood know the full details of this operation, but all will be revealed in time.\n\nGDI continue to threaten vital transportation routes, and you have been chosen to secure one such route in Egypt.\n\nGDI is blockading the Nile river with their fleet, and this is unacceptably delaying our progress.\n\nEstablish a foothold, then your objective is to destroy the GDI anti-aircraft systems that line the river bank. Once those are out of the way, Kane has a surprise in store for GDI's navy.
 	-ScriptLobbyDropdown@DIFFICULTY:
 	ScriptLobbyDropdown@DIFFICULTY:
 		ID: prologuedifficulty


### PR DESCRIPTION
Furthermore, I think the briefings could be much easier to read if [block strings](https://yaml-multiline.info/) were used. Unfortunately, this would mean changing the indentation of the whole file from tabs to spaces.

```yaml
World:
    LuaScript:
        Scripts: campaign.lua, ca-prologue-04.lua
    MissionData:
        Briefing: >
            Critical components and supplies are being transported to a secret
            staging area. Few in the Brotherhood know the full details of this
            operation, but all will be revealed in time.\n

            GDI continue to threaten vital transportation routes, and you have
            been chosen to secure one such route in Egypt.\n

            GDI is blockading the Nile river with their fleet, and this is
            unacceptably delaying our progress.\n

            Establish a foothold, then your objective is to destroy the GDI
            anti-aircraft systems that line the river bank. Once those are out
            of the way, Kane has a surprise in store for GDI's navy.
    -ScriptLobbyDropdown@DIFFICULTY:
    ScriptLobbyDropdown@DIFFICULTY:
        ID: prologuedifficulty
        Label: dropdown-difficulty.label
        Description: dropdown-difficulty.description
        Values:
            easy: options-difficulty.easy
        Default: easy
        Locked: True
    MusicPlaylist:
        StartingMusic: fist226m
    MapOptions:
        TechLevel: medium
```