### PR TITLE
Add idle factory alert

### DIFF
--- a/OpenRA.Mods.CA/Widgets/Logic/Ingame/ProductionTabsLogicCA.cs
+++ b/OpenRA.Mods.CA/Widgets/Logic/Ingame/ProductionTabsLogicCA.cs
@@ -45,6 +45,24 @@ namespace OpenRA.Mods.CA.Widgets.Logic
 			var icon = button.Get<ImageWidget>("ICON");
 			icon.GetImageName = () => button.IsDisabled() ? chromeName + "-disabled" :
 				tabs.Groups[button.ProductionGroup].Alert ? chromeName + "-alert" : chromeName;
+
+			var defaultIsVisible = icon.IsVisible;
+			icon.IsVisible = () =>
+			{
+				if (!defaultIsVisible())
+					return false;
+
+				var group = tabs.Groups[button.ProductionGroup];
+				if (!group.Alert && group.HasIdleFactories
+					&& tabs.QueueGroup != button.ProductionGroup
+					&& Game.Settings.Game.IdleFactoryAlert)
+				{
+					// Blink by toggling visibility using sine wave
+					return Math.Sin(Game.LocalTick * tabs.IdleAlertBlinkRate * 2 * Math.PI) > -0.3;
+				}
+
+				return true;
+			};
 		}
 
 		[ObjectCreator.UseCtor]

--- a/OpenRA.Mods.CA/Widgets/ProductionTabsCAWidget.cs
+++ b/OpenRA.Mods.CA/Widgets/ProductionTabsCAWidget.cs
@@ -25,6 +25,8 @@ namespace OpenRA.Mods.CA.Widgets
 		public string Name;
 		public ProductionQueue Queue;
 		public Actor Actor;
+		public int IdleTicks;
+		public bool IsIdle;
 	}
 
 	public class ProductionTabGroupCA
@@ -32,6 +34,7 @@ namespace OpenRA.Mods.CA.Widgets
 		public List<ProductionTabCA> Tabs = new List<ProductionTabCA>();
 		public string Group;
 		public bool Alert { get { return Tabs.Any(t => t.Queue.AllQueued().Any(i => i.Done)); } }
+		public bool HasIdleFactories { get { return Tabs.Any(t => t.IsIdle); } }
 
 		public void Update(IEnumerable<ProductionQueue> allQueues)
 		{
@@ -95,6 +98,12 @@ namespace OpenRA.Mods.CA.Widgets
 
 		public readonly Color TabColor = Color.White;
 		public readonly Color TabColorDone = Color.Gold;
+
+		public readonly int IdleAlertDelay = 250;
+
+		public readonly HashSet<string> IdleAlertGroups = new() { "Infantry", "Vehicle", "Aircraft", "Ship" };
+
+		public readonly float IdleAlertBlinkRate = 0.08f;
 
 		int contentWidth = 0;
 		bool leftPressed = false;
@@ -257,7 +266,21 @@ namespace OpenRA.Mods.CA.Widgets
 				// Draw number label
 				var textSize = font.Measure(tab.Name);
 				var position = new int2(rect.X + (rect.Width - textSize.X) / 2, (rect.Y + (rect.Height - textSize.Y) / 2) - 1);
-				font.DrawText(tab.Name, position, tab.Queue.AllQueued().Any(i => i.Done) ? TabColorDone : TabColor);
+
+				Color tabTextColor;
+				var showText = true;
+				if (tab.Queue.AllQueued().Any(i => i.Done))
+					tabTextColor = TabColorDone;
+				else if (tab.IsIdle && !highlighted)
+				{
+					tabTextColor = TabColor;
+					showText = Math.Sin(Game.LocalTick * IdleAlertBlinkRate * 2 * Math.PI) > -0.3;
+				}
+				else
+					tabTextColor = TabColor;
+
+				if (showText)
+					font.DrawText(tab.Name, position, tabTextColor);
 
 				tabsShown++;
 			}
@@ -348,6 +371,40 @@ namespace OpenRA.Mods.CA.Widgets
 			if (shouldUpdateQueues)
 				foreach (var g in Groups.Values)
 					g.Update(cachedProductionQueueEnabledStates.Select(t => t.Queue));
+
+			// Track idle ticks for each tab in groups that support idle alerts
+			if (Game.Settings.Game.IdleFactoryAlert)
+			{
+				foreach (var g in Groups.Values)
+				{
+					if (!IdleAlertGroups.Contains(g.Group))
+						continue;
+
+					foreach (var tab in g.Tabs)
+					{
+						var currentItem = tab.Queue.CurrentItem();
+						if (currentItem == null || currentItem.Paused)
+						{
+							tab.IdleTicks++;
+							tab.IsIdle = tab.IdleTicks >= IdleAlertDelay;
+						}
+						else
+						{
+							tab.IdleTicks = 0;
+							tab.IsIdle = false;
+						}
+					}
+				}
+			}
+			else
+			{
+				foreach (var g in Groups.Values)
+					foreach (var tab in g.Tabs)
+					{
+						tab.IdleTicks = 0;
+						tab.IsIdle = false;
+					}
+			}
 		}
 
 		public override bool YieldMouseFocus(MouseInput mi)

--- a/mods/ca/chrome/ingame-player.yaml
+++ b/mods/ca/chrome/ingame-player.yaml
@@ -735,6 +735,9 @@ Container@PLAYER_WIDGETS:
 					TabWidth: 31
 					TabSpacing: 3
 					ArrowWidth: 17
+					IdleAlertDelay: 250
+					IdleAlertGroups: Infantry, Vehicle, Aircraft, Ship
+					IdleAlertBlinkRate: 0.08
 					Logic: AddFactionSuffixLogicCA, ProductionTabsLogicCA
 					PaletteWidget: PRODUCTION_PALETTE
 					TypesContainer: PRODUCTION_TYPES

--- a/mods/ca/chrome/settings-display.yaml
+++ b/mods/ca/chrome/settings-display.yaml
@@ -225,6 +225,17 @@ Container@DISPLAY_PANEL:
 									Text: Selected Unit Tooltip
 									TooltipText: When a single unit/structure is selected, show info about it in bottom right corner
 									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
+						Container@IDLE_FACTORY_ALERT_CHECKBOX_CONTAINER:
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 10
+							Children:
+								Checkbox@IDLE_FACTORY_ALERT_CHECKBOX:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: Idle Factory Alert
+									TooltipText: Flash production tabs and sidebar icons when a factory is idle
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Container@SPACER:
 				Background@VIDEO_SECTION_HEADER:
 					X: 5


### PR DESCRIPTION
Adds a visual alert for idle unit-producing factories. When a factory's production queue is empty or on hold for 10 seconds, the tab number and sidebar icon blink to draw attention.

**User story:**
As a player, I want to be notified when my unit-producing factories are idle or on hold, so that I can keep my production running and avoid wasting time.

**Behavior:**
- Tab numbers blink when their factory is idle or on hold and not currently selected
- Sidebar icons blink when any factory in that group is idle and the group is not currently selected
- Completed items (gold) take priority over idle blink
- Configurable via YAML: `IdleAlertDelay`, `IdleAlertGroups`, `IdleAlertBlinkRate`
- Player-toggleable via Settings > Display > "Idle Factory Alert" checkbox (default: on)

<img width="915" height="612" alt="image" src="https://github.com/user-attachments/assets/995c5606-c43d-4cae-9c67-91ae816fedf1" />


https://github.com/user-attachments/assets/3a2a63f1-cd57-4812-ab96-5df76bb51dca


Depends on engine PR: https://github.com/Inq8/OpenRA/pull/1