### PR TITLE
Add harvester auto-resume

### DIFF
--- a/OpenRA.Mods.CA/Traits/HarvesterAutoResume.cs
+++ b/OpenRA.Mods.CA/Traits/HarvesterAutoResume.cs
@@ -1,0 +1,45 @@
+#region Copyright & License Information
+/**
+ * Copyright (c) The OpenRA Combined Arms Developers (see CREDITS).
+ * This file is part of OpenRA Combined Arms, which is free software.
+ * It is made available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version. For more information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.CA.Traits
+{
+	[Desc("Automatically orders idle harvesters to resume harvesting after a configurable delay.")]
+	class HarvesterAutoResumeInfo : ConditionalTraitInfo
+	{
+		[Desc("Delay in ticks before an idle harvester will automatically resume harvesting.")]
+		public readonly int ResumeDelay = 250;
+
+		public override object Create(ActorInitializer init) { return new HarvesterAutoResume(this); }
+	}
+
+	class HarvesterAutoResume : ConditionalTrait<HarvesterAutoResumeInfo>, INotifyIdle
+	{
+		int idleTicks;
+
+		public HarvesterAutoResume(HarvesterAutoResumeInfo info)
+			: base(info) { }
+
+		void INotifyIdle.TickIdle(Actor self)
+		{
+			if (IsTraitDisabled)
+				return;
+
+			if (++idleTicks < Info.ResumeDelay)
+				return;
+
+			idleTicks = 0;
+			self.QueueActivity(new FindAndDeliverResources(self));
+		}
+	}
+}

--- a/mods/ca/rules/defaults.yaml
+++ b/mods/ca/rules/defaults.yaml
@@ -1690,6 +1690,8 @@
 		SearchFromHarvesterRadius: 8
 		HarvestFacings: 8
 		EmptyCondition: no-ore
+	HarvesterAutoResume:
+		ResumeDelay: 250
 	DockClientManager:
 	WithStoresResourcesPipsDecoration:
 		Position: BottomLeft


### PR DESCRIPTION
Adds automatic harvesting resumption for idle harvesters. When a harvester becomes idle (e.g., after completing a move order), it will automatically resume harvesting after a configurable delay.

**User story:**
As a player, I want my harvesters to automatically resume harvesting after I move them out of danger or slightly misclick, so that I don't lose income from forgetting to re-issue harvest orders.

**Behavior:**
- After a harvester becomes idle for any reason, it waits a configurable delay then automatically queues a new harvest order
- Default delay is 250 ticks (~10 seconds at normal game speed), giving the player time to issue follow-up orders
- Works for all idle scenarios: completed move orders, attack orders, scatter, stop, etc.
- Full harvesters will route to a refinery to unload first (handled by existing `FindAndDeliverResources` logic)
- Implemented as a standalone conditional trait (`HarvesterAutoResume`) — can be disabled per-unit via conditions
- Configurable via YAML: `ResumeDelay`